### PR TITLE
Fail build on any error

### DIFF
--- a/api_authz/Makefile
+++ b/api_authz/Makefile
@@ -11,8 +11,7 @@ build: image
 image:
 	docker build -t $(REPOSITORY):latest \
 		-t $(REPOSITORY):$(VERSION) \
-		-f ./docker/Dockerfile \
-		.
+		./docker
 
 .PHONY: push
 push: build

--- a/build/make-all.sh
+++ b/build/make-all.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 TARGET=$1
 
 if [ -z "${TARGET}" ]; then


### PR DESCRIPTION
The make-all.sh script wasn't using set -e so errors were not causing the build to fail.