### PR TITLE
Edit /pam_authz Makefile target `up`.

### DIFF
--- a/pam_authz/Makefile
+++ b/pam_authz/Makefile
@@ -28,4 +28,4 @@ push: build
 
 .PHONY: up
 up:
-	docker-compose -f docker/docker-compose.yaml up
+	docker-compose -f docker/docker-compose.yaml up --force-recreate

--- a/pam_authz/README.md
+++ b/pam_authz/README.md
@@ -39,7 +39,7 @@ $ ssh -p 2222 ops@localhost -o StrictHostKeyChecking=no -o UserKnownHostsFile=/d
 
 Enter `ramesh` and `suresh` in the prompts that follow to get access.
 
-This behavior can be modified by changing the policies in the directoy mentioned above.
+This behavior can be modified by changing the policies in the directory mentioned above.
 
 #### Modify OpenSSH
 

--- a/pam_authz/pam/display.c
+++ b/pam_authz/pam/display.c
@@ -13,7 +13,7 @@
 
 static const int DISPLAY_STYLE_INVALID = -1;
 
-// Diplay style constants used in OPA.
+// Display style constants used in OPA.
 static const char DISPLAY_STYLE_PROMPT_ECHO_ON[]  = "prompt_echo_on";
 static const char DISPLAY_STYLE_PROMPT_ECHO_OFF[] = "prompt_echo_off";
 static const char DISPLAY_STYLE_TEXT_INFO[]       = "info";


### PR DESCRIPTION
Add flag `--force-recreate` to `docker-compose up` command so that trial containers don't persist. 
Also fixed a couple of typos.