### PR TITLE
Add push target to kafka_authorizer

### DIFF
--- a/kafka_authorizer/Makefile
+++ b/kafka_authorizer/Makefile
@@ -1,4 +1,5 @@
 VERSION := $(shell ./scripts/get-version.sh)
+REPOSITORY := openpolicyagent/demo-kafka
 
 clean:
 	rm -fr target
@@ -7,7 +8,11 @@ build: jar image
 
 image:
 	sed s/VERSION/$(VERSION)/g Dockerfile.in > Dockerfile
-	docker build -t openpolicyagent/demo-kafka:$(VERSION) .
+	docker build -t openpolicyagent/demo-kafka:$(VERSION) -t openpolicyagent/demo-kafka:latest .
 
 jar:
 	./scripts/build.sh
+
+push: build
+	docker push $(REPOSITORY):$(VERSION)
+	docker push $(REPOSITORY):latest


### PR DESCRIPTION
Forgot to include push target in original PR. All subdirs with
publishable artifacts should include a push target for convenience.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>