### PR TITLE
Add quote option to data filter example and improve CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+/opa
+/opa_linux_amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ go:
 - '1.10'
 services:
 - docker
+install:
+  - ./build/install-opa.sh
+  - export PATH=$PATH:$PWD
 script: make build

--- a/build/install-opa.sh
+++ b/build/install-opa.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+curl https://api.github.com/repos/open-policy-agent/opa/releases/latest |
+    grep 'browser_download_url.*linux_amd64' |
+    cut -d : -f 2,3 |
+    tr -d '"' |
+    wget -qi -
+
+chmod u+x opa_linux_amd64
+ln -s opa_linux_amd64 opa

--- a/data_filter_example/Makefile
+++ b/data_filter_example/Makefile
@@ -1,0 +1,13 @@
+build: env
+	. env/bin/activate; pytest .
+
+env: env/bin/activate
+
+env/bin/activate:
+	test -d env || virtualenv env
+	. env/bin/activate; pip install -Ur requirements.txt; pip install -e .
+	touch env/bin/activate
+
+clean:
+	rm -fr env
+	rm -fr *.egg-info

--- a/data_filter_example/data_filter_example/opa.py
+++ b/data_filter_example/data_filter_example/opa.py
@@ -126,14 +126,16 @@ def compile(q, input, unknowns, from_table=None):
     return Result(True, clauses)
 
 
-def splice(SELECT, FROM, WHERE='', decision=None):
+def splice(SELECT, FROM, WHERE='', decision=None, sql_kwargs=None):
     """Returns a SQL query as a string constructed from the caller's provided
     values and the decision returned by compile."""
     sql = 'SELECT ' + SELECT + ' FROM ' + FROM
     if decision is not None and decision.sql is not None:
         queries = [sql] * len(decision.sql.clauses)
         for i, clause in enumerate(decision.sql.clauses):
-            queries[i] = queries[i] + ' ' + clause.sql()
+            if sql_kwargs is None:
+                sql_kwargs = {}
+            queries[i] = queries[i] + ' ' + clause.sql(**sql_kwargs)
             if WHERE:
                 queries[i] = queries[i] + ' AND (' + WHERE + ')'
     return ' UNION '.join(queries)

--- a/data_filter_example/data_filter_example/sql.py
+++ b/data_filter_example/data_filter_example/sql.py
@@ -11,34 +11,34 @@ class InnerJoin(object):
         self.tables = tables
         self.expr = expr
 
-    def sql(self):
-        return ' '.join(['INNER JOIN ' + t for t in self.tables]) + ' ON ' + self.expr.sql()
+    def sql(self, **kwargs):
+        return ' '.join(['INNER JOIN ' + t for t in self.tables]) + ' ON ' + self.expr.sql(**kwargs)
 
 
 class Where(object):
     def __init__(self, expr):
         self.expr = expr
 
-    def sql(self):
-        return 'WHERE ' + self.expr.sql()
+    def sql(self, **kwargs):
+        return 'WHERE ' + self.expr.sql(**kwargs)
 
 
 class Disjunction(object):
     def __init__(self, conjunction):
         self.conjunction = conjunction
 
-    def sql(self):
-        return '(' + " OR ".join([c.sql() for c in self.conjunction]) + ')'
+    def sql(self, **kwargs):
+        return '(' + " OR ".join([c.sql(**kwargs) for c in self.conjunction]) + ')'
 
 
 class Conjunction(object):
     def __init__(self, relation):
         self.relation = relation
 
-    def sql(self):
+    def sql(self, **kwargs):
         if len(self.relation) == 0:
             return '1'
-        return '(' + " AND ".join([r.sql() for r in self.relation]) + ')'
+        return '(' + " AND ".join([r.sql(**kwargs) for r in self.relation]) + ')'
 
 
 class Relation(object):
@@ -47,8 +47,8 @@ class Relation(object):
         self.lhs = lhs
         self.rhs = rhs
 
-    def sql(self):
-        return "%s %s %s" % (self.lhs.sql(), self.operator.sql(), self.rhs.sql())
+    def sql(self, **kwargs):
+        return "%s %s %s" % (self.lhs.sql(**kwargs), self.operator.sql(**kwargs), self.rhs.sql(**kwargs))
 
 
 class Column(object):
@@ -56,7 +56,7 @@ class Column(object):
         self.table = table
         self.name = name
 
-    def sql(self):
+    def sql(self, **kwargs):
         if self.table:
             return "%s.%s" % (self.table, self.name)
         return str(self.name)
@@ -67,15 +67,18 @@ class Call(object):
         self.operator = operator
         self.operands = operands
 
-    def sql(self):
-        return self.operator + '(' + ', '.join(o.sql() for o in self.operands) + ')'
+    def sql(self, **kwargs):
+        return self.operator + '(' + ', '.join(o.sql(**kwargs) for o in self.operands) + ')'
 
 
 class Constant(object):
     def __init__(self, value):
         self.value = value
 
-    def sql(self):
+    def sql(self, **kwargs):
+        if kwargs.get('use_single_quotes', False):
+            if isinstance(self.value, basestring):
+                return "'" + self.value + "'"
         return json.dumps(self.value)
 
 
@@ -83,7 +86,7 @@ class RelationOp(object):
     def __init__(self, value):
         self.value = value
 
-    def sql(self):
+    def sql(self, **kwargs):
         return self.value
 
 

--- a/data_filter_example/tests/test_opa.py
+++ b/data_filter_example/tests/test_opa.py
@@ -362,6 +362,14 @@ def test_compile_multi_table(note, input, policy, exp_defined, exp_sql):
         clauses,
     )
 
+def test_single_quote_option():
+    clear_policies()
+    put_policy('''package test
+    p { data.q[x].a = "foo" }
+    ''')
+    result = opa.compile('data.test.p == true', {}, ['q'], 'q')
+    assert [c.sql(use_single_quotes=True) for c in result.sql.clauses] == ["WHERE ((q.a = 'foo'))"]
+
 
 def crunch(query, input, unknowns, from_table, policy, exp_defined, exp_sql):
     clear_policies()


### PR DESCRIPTION
These commits are somewhat independent but I made them all in a row and figured there was no reason to split up PRs at this point. Each commit is fairly self explanatory. With these changes:

- callers can control how SQL predicates are rendered as strings
- the filter integration tests use `opa eval` instead of requiring an OPA API endpoint
- the tests should executed as part of the CI
- the CI has been updated to install the latest stable version of OPA into the `$PATH`

I'm guessing something will break. Let's see.