### PR TITLE
Update decision logger example

### DIFF
--- a/decision_logger_plugin_example/main.go
+++ b/decision_logger_plugin_example/main.go
@@ -47,7 +47,7 @@ func (p *PrintlnLogger) Reconfigure(ctx context.Context, config interface{}) {
 	p.config = config.(Config)
 }
 
-func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) {
+func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	w := os.Stdout
@@ -55,6 +55,7 @@ func (p *PrintlnLogger) Log(ctx context.Context, event logs.EventV1) {
 		w = os.Stderr
 	}
 	fmt.Fprintln(w, event) // ignoring errors!
+	return nil
 }
 
 func Init() error {


### PR DESCRIPTION
We modified the decision logger interface to allow implementations to
return errors.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>