### PR TITLE
Update api_authz example to use OPA v0.10.5

### DIFF
--- a/api_authz/docker/docker-compose-token.yaml
+++ b/api_authz/docker/docker-compose-token.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:0.4.9
+    image: openpolicyagent/opa:0.10.5
     ports:
       - 8181:8181
     command:

--- a/api_authz/docker/docker-compose.yaml
+++ b/api_authz/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:0.4.9
+    image: openpolicyagent/opa:0.10.5
     ports:
       - 8181:8181
     command:


### PR DESCRIPTION
Update the docker-compose files for `api_authz` example to fix #49 