### PR TITLE
Update pam_authz build

### DIFF
--- a/pam_authz/docker/docker-compose.yaml
+++ b/pam_authz/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:0.4.8
+    image: openpolicyagent/opa:0.10.7
     ports:
       - 8181:8181
     command:

--- a/pam_authz/docker/pam-builder.dockerfile
+++ b/pam_authz/docker/pam-builder.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.11
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Increases the version of the golang container used to build the module,
and increases the version of opa used in the docker-compose example

Signed-off-by: Andy Curtis <arcurtis@gmail.com>