### PR TITLE
Add example javascript wasm app (Cloudflare worker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *~
 /opa
 /opa_linux_amd64
+wasm/cloudflare-worker/dist
+wasm/cloudflare-worker/node_modules
+*.wasm

--- a/wasm/cloudflare-worker/README.md
+++ b/wasm/cloudflare-worker/README.md
@@ -1,0 +1,169 @@
+# WASM Policy Worker
+This example shows making a [Cloudflare Worker](https://www.cloudflare.com/products/cloudflare-workers/)
+which can enforce Rego Policies that have been compiled into WebAssembly (wasm).
+
+## The Worker
+
+The worker is a single javascript file that uses some `npm` modules, most importantly
+the [@open-policy-agent/opa-wasm](https://github.com/open-policy-agent/npm-opa-wasm)
+module.
+
+Because the Cloudflare worker should be a single self-contained script we will use
+[Webpack](https://webpack.js.org/) to build a `bundle.js` that includes the `npm` modules.
+
+Build the worker using:
+
+```bash
+# Install dependencies
+npm install
+
+# Build with webpack
+npm run build
+```
+
+The output of the build goes into the `./dist` directory.
+
+## The policy
+Using the `example.rego` file build it with:
+
+```bash
+opa build -d example.rego 'data.example.allow = true'
+```
+
+The input for the policy is going to be a JSON string like:
+
+```json
+{
+  "fetcher": {},
+  "redirect": "manual",
+  "headers": {},
+  "url": "https://opa4fun.com/",
+  "method": "GET",
+  "bodyUsed": false,
+  "body": null
+}
+```
+
+The policy is only giving a boolean response for `data.example.allow == true`, in the
+`example.rego` policy file that means that it is a `GET` request or a `POST` to `/api`.
+
+The policy itself isn't very exciting, but acts as a proof of concept. With access to
+the full `Request` and `Response` objects plus additional Cloudflare API's and headers
+you can do some pretty powerful things.
+
+
+## Uploading the Cloudflare worker
+
+### Prerequisites
+
+Before using workers you must have a Cloudflare account and a site configured to use
+Cloudflare. See (https://www.cloudflare.com/)[https://www.cloudflare.com/] for instructions
+to get started.
+
+You must also have Workers enabled. See
+[https://www.cloudflare.com/products/cloudflare-workers/](https://www.cloudflare.com/products/cloudflare-workers/)
+
+### Test It/Upload Via Editor
+Open up the Editor in the Cloudflare dashboard and copy in the `dist/bundle.js` contents.
+Then upload the `policy.wasm` file as a "Resource" with the name `REGO_WASM` (needs to match
+the variable used in the code).
+
+From the Editor you can configure & deploy the worker.
+
+### Upload via API
+
+Alternatively, and arguably easier (once the worker is stable), they can
+be managed via API's.
+
+For the commands shown below either setup some env variables for CF
+credentials and account info, or substitute values manually as required. See
+https://developers.cloudflare.com/workers/api/ for details. 
+
+```bash
+export CF_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxx
+export CF_EMAIL=example@gmail.com
+export CF_ZONE_ID=yyyyyyyyyyyyyyyyyyyyyyy
+```
+
+Below are some helpers to make API calls. The official documentation is the
+best source of truth, but these should help get started.
+
+## Create a route
+
+The worker script needs to be associated with a route. Start by creating one,
+or checking if some exist already (see below).
+
+> Make sure to substitute the domain name for your application, the example
+  below is using a fake url `example.com`
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/workers/filters" \
+    -H "X-Auth-Email:${CF_EMAIL}" \
+    -H "X-Auth-Key:${CF_API_KEY}" \
+    -H "Content-type: application/json" \
+    -d '{"pattern": "example.com/*", "enabled": true}'
+```
+
+This example just adds a route that will catch pretty much any API call for the site. See
+[https://developers.cloudflare.com/workers/api/route-matching/](https://developers.cloudflare.com/workers/api/route-matching/) for more details on configuring the route.
+
+## Get a route
+
+```bash
+curl -X GET "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/workers/filters" \
+    -H "X-Auth-Email:${CF_EMAIL}" \
+    -H "X-Auth-Key:${CF_API_KEY}"
+```
+_Initially this should be empty_
+
+
+## POST a new worker/update the worker
+
+This uses the [Resource Bindings API](https://developers.cloudflare.com/workers/api/resource-bindings/) to upload both a script and wasm binary together, with bindings
+for how to load the WebAssembly.
+
+The key being the [metadata_wasm.json](./metadata_wasm.json) file which defines what
+variable in the worker context to bind the loaded wasm module to, as well as the
+form parts that are the script and assembly files.
+
+```bash
+curl -X PUT "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/workers/script" \
+    -H "X-Auth-Email:${CF_EMAIL}" \
+    -H "X-Auth-Key:${CF_API_KEY}" \
+    -F 'metadata=@metadata_wasm.json;type=application/json' \
+    -F 'wasmpolicy=@policy.wasm;type=application/wasm' \
+    -F 'script=@./dist/bundle.js;type=application/javascript'
+```
+
+## GET the current worker
+
+```bash
+curl -X GET "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/workers/script" \
+    -H "X-Auth-Email:${CF_EMAIL}" \
+    -H "X-Auth-Key:${CF_API_KEY}"
+```
+
+_Initially this should be empty_
+
+
+# Exercising the policy
+
+For the example policy you can verify it works by making requests like:
+
+```bash
+curl -svL -X GET https://${DOMAIN_NAME}/
+```
+With a successful `200` response (depends on the backing HTTP service).
+
+
+```bash
+curl -svL -X PUT https://${DOMAIN_NAME}/
+```
+
+With a `403` response like:
+
+```json
+{
+  "error": "Not allowed by policy"
+}
+```

--- a/wasm/cloudflare-worker/example.rego
+++ b/wasm/cloudflare-worker/example.rego
@@ -1,0 +1,10 @@
+package example
+
+allow {
+    input.method = "GET"
+}
+
+allow {
+    input.method = "POST"
+    input.path = "/api"
+}

--- a/wasm/cloudflare-worker/index.js
+++ b/wasm/cloudflare-worker/index.js
@@ -1,0 +1,54 @@
+const Rego = require("@open-policy-agent/opa-wasm")
+
+// REGO_WASM is the resource the compiled policy is loaded into
+var policy_wasm = REGO_WASM
+
+addEventListener('fetch', event => {
+    event.respondWith(handleRequest(event.request))
+})
+
+// Load WASM compiled policy, the loading is done asynchronously.
+var rego = new Rego()
+var loaded_policy = null
+rego.load_policy(policy_wasm).then(policy => {
+    loaded_policy = policy
+}, error => {
+    console.error("failed to load policy: " + error)
+})
+
+async function handleRequest(request) {
+    //console.time("eval")
+    
+    // The policy may not have been loaded yet..
+    // until then deny everything
+    if (loaded_policy == null) {
+        return new Response('{"error": "Policy not ready yet."}',
+        { status: 503, statusText: "Service Unavailable" })
+    }
+
+    // the Request object doesn't have a "path"
+    // field, only "url". So we add it ourselves
+    url = new URL(request.url)
+    request.path = url.pathname
+
+    input_json = JSON.stringify(request)
+    
+    //console.log(input_json)
+
+    allow = loaded_policy.eval_bool(input_json)
+    
+    //console.log("allow = " + allow)
+
+    if (!allow) {
+        // Short circuit the request here.
+        return new Response('{"error": "Not allowed by policy"}',
+        { status: 403, statusText: "Forbidden" })
+    }
+    
+    // Allowed request
+    
+    const response = await fetch(request)
+
+    //console.timeEnd("eval")
+    return response
+}

--- a/wasm/cloudflare-worker/metadata_wasm.json
+++ b/wasm/cloudflare-worker/metadata_wasm.json
@@ -1,0 +1,10 @@
+{
+    "body_part": "script",
+    "bindings": [
+      {
+        "name": "REGO_WASM",
+        "type": "wasm_module",
+        "part": "wasmpolicy"
+      }
+    ]
+  }     

--- a/wasm/cloudflare-worker/package-lock.json
+++ b/wasm/cloudflare-worker/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "cloudflare-worker",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@open-policy-agent/opa-wasm": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@open-policy-agent/opa-wasm/-/opa-wasm-0.0.2.tgz",
+      "integrity": "sha512-Wqh4thbfT7CyNmbQx3UFfynJKbWKfpbgA5BCJtCBEZDUJVmb5JNk/qWaWWxWQmhpYjWmodo9GUunvqxU4rqucw=="
+    }
+  }
+}

--- a/wasm/cloudflare-worker/package.json
+++ b/wasm/cloudflare-worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cloudflare-worker",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "@open-policy-agent/opa-wasm": "^1.0.0"
+  },
+  "scripts": {
+    "build": "webpack"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/wasm/cloudflare-worker/webpack.config.js
+++ b/wasm/cloudflare-worker/webpack.config.js
@@ -1,0 +1,34 @@
+const path = require('path')
+
+module.exports = {
+  entry: {
+    bundle: path.join(__dirname, './index.js'),
+  },
+
+  output: {
+    filename: 'bundle.js',
+    path: path.join(__dirname, 'dist'),
+  },
+
+  target: 'webworker',
+
+  // Switch to production for minified javascript
+  mode: 'development',
+  //mode: 'production', 
+
+  watchOptions: {
+    ignored: /dist/g,
+  },
+
+  devtool: "source-map",
+
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.json', '.wasm'],
+    plugins: [],
+  },
+
+  module: {
+    rules: [
+    ],
+  },
+}


### PR DESCRIPTION
The application itself isn’t super exciting but shows a couple of cool
things. First off this is a working example of using the new
`@open-policy-agent/opa-wasm` npm module. It also shows Cloudflare
workers (CDN edge compute) that can apply Rego policies on requests.