### PR TITLE
travis: Update to Go 1.11 from Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 go:
-- '1.10'
+- '1.11'
 services:
 - docker
 install:


### PR DESCRIPTION
This unblocks @urvil38 who is working on a OPA-IPTables integration
for GSoC 2019.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>