### PR TITLE
Bind mount the sshd_config file so that changes are reflected

### DIFF
--- a/pam_authz/docker/docker-compose.yaml
+++ b/pam_authz/docker/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       - "2222:22"
     volumes:
       - ./etc/frontend_host_id:/etc/host_identity.json
+      - ./etc/sshd_config:/etc/ssh/sshd_config
 
   backend:
     image: openpolicyagent/demo-pam
@@ -37,3 +38,4 @@ services:
       - "2223:22"
     volumes:
       - ./etc/backend_host_id:/etc/host_identity.json
+      - ./etc/sshd_config:/etc/ssh/sshd_config


### PR DESCRIPTION
[This section](https://github.com/danielpops/contrib/tree/master/pam_authz#modify-openssh) in the README for the pam_authz example says:

```
Modify OpenSSH
To modify OpenSSH's behavior, edit /docker/etc/sshd_config.

For example you can change the line

AuthenticationMethods keyboard-interactive
to

AuthenticationMethods publickey,keyboard-interactive
The SSH server will now require both this key and PAM module authorization before it grants access.
```

But that local copy wasn't being reflected in the launched containers. This PR fixes that by bind-mounting docker/etc/sshd_config to /etc/ssh/sshd_config