### PR TITLE
Switch library order for newer Ubuntu.

### DIFF
--- a/pam_authz/pam/Makefile
+++ b/pam_authz/pam/Makefile
@@ -5,7 +5,7 @@ all: module
 
 module: http flag display authz log json pull sysinfo
 	gcc -fPIC -fno-stack-protector -c pam.c -o ${MODULE}.o
-	gcc -shared -lcurl -ljansson -Wl,-soname,${MODULE}.so -o ${MODULE}.so ${MODULE}.o $(foreach var,$?,$(var).o)
+	gcc -shared -Wl,-soname,${MODULE}.so -o ${MODULE}.so ${MODULE}.o $(foreach var,$?,$(var).o) -lcurl -ljansson -lpam
 
 	${CLEAN_OBJECTS}
 


### PR DESCRIPTION
Ubuntu 18.04.2 LTS was unable to build a working plugin without the reordering.