### PR TITLE
Add pam_authz support for unix socket to opa.

### DIFF
--- a/pam_authz/pam/README.md
+++ b/pam_authz/pam/README.md
@@ -74,6 +74,7 @@ The module accepts arguments of the format `<flag>=<value>`.
 |Property           |Required   |Description|
 |-------------------|-----------|-----------|
 |`url`              |yes        |The URL of an OPA instance API.
+|`sock`             |no         |The path to a unix socket OPA is listening on.
 |`display_endpoint` |no         |The path of the package containing policy that describes what to display or prompt the user.
 |`pull_endpoint`    |no         |The path of the package containing policy that describes the JSON files and environment variables that should be collected from the system.
 |`authz_endpoint`   |yes        |The path of the package containing the policy that takes all collected data as input and makes the final decision.
@@ -312,3 +313,7 @@ host requirements and verbose logs.
 ```bash
 ssh -p 2227 ops@<container-ip> -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -vvv
 ```
+
+## Security
+
+OPA should be secured so that non privileged users can not contact OPA and change policy or use it to help break in. This module does not yet support any authentication but when used in conjunction with the -sock flag, security can be enforced with unix file permissions (chown root.root opa.sock and chmod 600 opa.sock). Start the OPA server with -a unix://<path>/opa.sock.

--- a/pam_authz/pam/flag.c
+++ b/pam_authz/pam/flag.c
@@ -4,10 +4,11 @@
 #include "flag.h"
 #include "log.h"
 
-#define FLAG_COUNT 5
+#define FLAG_COUNT 6
 
 // Valid flags that can be used as arguments to this PAM module inside /etc/pam.d/ files.
 static const char FLAG_STR_OPA_URL[]          = "url";
+static const char FLAG_STR_OPA_SOCK[]         = "sock";
 static const char FLAG_STR_PULL_ENDPOINT[]    = "pull_endpoint";
 static const char FLAG_STR_DISPLAY_ENDPOINT[] = "display_endpoint";
 static const char FLAG_STR_AUTHZ_ENDPOINT[]   = "authz_endpoint";
@@ -15,6 +16,7 @@ static const char FLAG_STR_LOG_LEVEL[]        = "log_level";
 
 // Default values of exposed variables.
 char flag_opa_url[MAX_FLAG_SIZE]          = "";
+char flag_opa_sock[MAX_FLAG_SIZE]         = "";
 char flag_pull_endpoint[MAX_FLAG_SIZE]    = ""; 
 char flag_display_endpoint[MAX_FLAG_SIZE] = "";
 char flag_authz_endpoint[MAX_FLAG_SIZE]   = "";
@@ -25,6 +27,7 @@ static const struct FlagStrToVar {
 	const char *var;
 } FLAG_STR_TO_VAR[FLAG_COUNT] = {
 	{FLAG_STR_OPA_URL,          flag_opa_url},
+	{FLAG_STR_OPA_SOCK,         flag_opa_sock},
 	{FLAG_STR_PULL_ENDPOINT,    flag_pull_endpoint},
 	{FLAG_STR_DISPLAY_ENDPOINT, flag_display_endpoint},
 	{FLAG_STR_AUTHZ_ENDPOINT,   flag_authz_endpoint},

--- a/pam_authz/pam/flag.h
+++ b/pam_authz/pam/flag.h
@@ -6,6 +6,7 @@
 // These variables are populated by initialize_flags() using arguments
 // that this PAM module is called with.
 extern char flag_opa_url[MAX_FLAG_SIZE];
+extern char flag_opa_sock[MAX_FLAG_SIZE];
 extern char flag_pull_endpoint[MAX_FLAG_SIZE];
 extern char flag_display_endpoint[MAX_FLAG_SIZE];
 extern char flag_authz_endpoint[MAX_FLAG_SIZE];

--- a/pam_authz/pam/http.c
+++ b/pam_authz/pam/http.c
@@ -67,6 +67,9 @@ int http_request(const char * method, const char* endpoint, char *req_body, json
 	}
 
 	char url[2 * MAX_FLAG_SIZE];
+	if (strlen(flag_opa_sock) > 0) {
+		curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, flag_opa_sock);
+	}
 	curl_easy_setopt(curl_handle, CURLOPT_URL, join_url(url, flag_opa_url, endpoint));
 	curl_easy_setopt(curl_handle, CURLOPT_CUSTOMREQUEST, method);
 	curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1);


### PR DESCRIPTION
This change allows contacting OPA via unix socket rather then over tcp. This can be used to secure OPA when used with the pam module.