### PR TITLE
Allow kafka plugin to talk to authenticated opa server

### DIFF
--- a/kafka_authorizer/src/main/java/com/lbg/kafka/opa/OpaAuthorizer.java
+++ b/kafka_authorizer/src/main/java/com/lbg/kafka/opa/OpaAuthorizer.java
@@ -21,6 +21,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -82,6 +83,10 @@ public class OpaAuthorizer implements Authorizer {
     }
   }
 
+  public String getValueOrDefault(String property, String defaultValue) {
+    return Optional.ofNullable((String) configs.get(property)).orElse(defaultValue);
+  }
+
   public boolean authorize(Session session, Operation operation, Resource resource) {
     try {
       return cache.get(new Msg.Input(operation, resource, session));
@@ -95,11 +100,11 @@ public class OpaAuthorizer implements Authorizer {
     if (log.isTraceEnabled()) {
       log.trace("CONFIGS: {}", this.configs);
     }
-    opaUrl = (String) configs.get(OPA_AUTHORIZER_URL_CONFIG);
-    allowOnError = Boolean.valueOf((String) configs.get(OPA_AUTHORIZER_DENY_ON_ERROR_CONFIG));
-    initialCapacity = Integer.parseInt((String) configs.get(OPA_AUTHORIZER_CACHE_INITIAL_CAPACITY_CONFIG));
-    maximumSize = Integer.parseInt((String) configs.get(OPA_AUTHORIZER_CACHE_MAXIMUM_SIZE_CONFIG));
-    expireAfterMs = Long.parseLong((String) configs.get(OPA_AUTHORIZER_CACHE_EXPIRE_AFTER_MS_CONFIG));
+    opaUrl = (String) getValueOrDefault(OPA_AUTHORIZER_URL_CONFIG, "http://localhost:8181");
+    allowOnError = Boolean.valueOf((String) getValueOrDefault(OPA_AUTHORIZER_DENY_ON_ERROR_CONFIG, "false"));
+    initialCapacity = Integer.parseInt((String) getValueOrDefault(OPA_AUTHORIZER_CACHE_INITIAL_CAPACITY_CONFIG, "100"));
+    maximumSize = Integer.parseInt((String) getValueOrDefault(OPA_AUTHORIZER_CACHE_MAXIMUM_SIZE_CONFIG, "100"));
+    expireAfterMs = Long.parseLong((String) getValueOrDefault(OPA_AUTHORIZER_CACHE_EXPIRE_AFTER_MS_CONFIG, "600000"));
   }
 
   public void addAcls(scala.collection.immutable.Set<Acl> acls, Resource resource) {

--- a/kafka_authorizer/src/main/java/com/lbg/kafka/opa/OpaAuthorizer.java
+++ b/kafka_authorizer/src/main/java/com/lbg/kafka/opa/OpaAuthorizer.java
@@ -35,12 +35,14 @@ public class OpaAuthorizer implements Authorizer {
   private final static String OPA_AUTHORIZER_CACHE_INITIAL_CAPACITY_CONFIG = "opa.authorizer.cache.initial.capacity";
   private final static String OPA_AUTHORIZER_CACHE_MAXIMUM_SIZE_CONFIG = "opa.authorizer.cache.maximum.size";
   private final static String OPA_AUTHORIZER_CACHE_EXPIRE_AFTER_MS_CONFIG = "opa.authorizer.cache.expire.after.ms";
+  private final static String OPA_AUTHORIZER_TOKEN = "opa.authorizer.token";
 
   private String opaUrl;
   private boolean allowOnError;
   private int initialCapacity;
   private int maximumSize;
   private long expireAfterMs;
+  private String opaToken;
 
   private final Gson gson = new Gson();
 
@@ -66,6 +68,9 @@ public class OpaAuthorizer implements Authorizer {
       conn.setDoOutput(true);
       conn.setRequestMethod("POST");
       conn.setRequestProperty("Content-Type", "application/json");
+      if (!opaToken.isEmpty()) {
+        conn.setRequestProperty("Authorization", "Bearer " + opaToken);
+      }
 
       String data = gson.toJson(new Msg(input));
       OutputStream os = conn.getOutputStream();
@@ -105,6 +110,7 @@ public class OpaAuthorizer implements Authorizer {
     initialCapacity = Integer.parseInt((String) getValueOrDefault(OPA_AUTHORIZER_CACHE_INITIAL_CAPACITY_CONFIG, "100"));
     maximumSize = Integer.parseInt((String) getValueOrDefault(OPA_AUTHORIZER_CACHE_MAXIMUM_SIZE_CONFIG, "100"));
     expireAfterMs = Long.parseLong((String) getValueOrDefault(OPA_AUTHORIZER_CACHE_EXPIRE_AFTER_MS_CONFIG, "600000"));
+    opaToken = (String) getValueOrDefault(OPA_AUTHORIZER_TOKEN, "");
   }
 
   public void addAcls(scala.collection.immutable.Set<Acl> acls, Resource resource) {


### PR DESCRIPTION
This PR is to set up default parameters for kafka opa authorizer to avoid null pointer exceptions.
It also provides an option to use authentication token when talking to opa.