### PR TITLE
allow configuring outbound and inbound ports for envoy iptables rules

### DIFF
--- a/envoy_iptables/Makefile
+++ b/envoy_iptables/Makefile
@@ -1,5 +1,5 @@
 REPOSITORY := openpolicyagent/proxy_init
-VERSION := v3
+VERSION := v4
 
 .PHONY: all
 all: image

--- a/envoy_iptables/proxy_init.sh
+++ b/envoy_iptables/proxy_init.sh
@@ -6,9 +6,10 @@ set -o nounset
 set -o pipefail
 
 usage() {
-  echo "${0} -p PORT -u UID [-h]"
+  echo "${0} -p INBOUND_PORT -o OUTBOUND_PORT -u UID [-h]"
   echo ''
-  echo '  -p: Specify the envoy port to which redirect all TCP traffic'
+  echo '  -p: Specify the envoy port to which redirect all inbound TCP traffic'
+  echo '  -o: Specify the envoy port to which redirect all outbound TCP traffic'
   echo '  -u: Specify the UID of the user for which the redirection is not'
   echo '      applied. Typically, this is the UID of the proxy container'
   echo '  -i: Comma separated list of IP ranges in CIDR form to redirect to envoy (optional)'
@@ -17,10 +18,13 @@ usage() {
 
 IP_RANGES_INCLUDE=""
 
-while getopts ":p:u:e:i:h" opt; do
+while getopts ":p:o:u:e:i:h" opt; do
   case ${opt} in
     p)
-      ENVOY_PORT=${OPTARG}
+      ENVOY_IN_PORT=${OPTARG}
+      ;;
+    o)
+      ENVOY_OUT_PORT=${OPTARG}
       ;;
     u)
       ENVOY_UID=${OPTARG}
@@ -40,55 +44,52 @@ while getopts ":p:u:e:i:h" opt; do
   esac
 done
 
-if [[ -z "${ENVOY_PORT-}" ]] || [[ -z "${ENVOY_UID-}" ]]; then
+if [[ -z "${ENVOY_IN_PORT-}" ]] || [[ -z "${ENVOY_UID-}" ]]; then
   echo "Please set both -p and -u parameters"
   usage
   exit 1
 fi
 
-# Create a new chain for redirecting inbound and outbound traffic to
-# the common Envoy port.
-iptables -t nat -N ISTIO_REDIRECT                                             -m comment --comment "istio/redirect-common-chain"
-iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-port ${ENVOY_PORT}  -m comment --comment "istio/redirect-to-envoy-port"
+# Create a new chain for redirecting inbound traffic to Envoy port
+iptables -t nat -N ENVOY_IN_REDIRECT                                                    -m comment --comment "envoy/redirect-inbound-chain"
+iptables -t nat -A ENVOY_IN_REDIRECT -p tcp -j REDIRECT --to-port ${ENVOY_IN_PORT}      -m comment --comment "envoy/redirect-to-envoy-inbound-port"
 
 # Redirect all inbound traffic to Envoy.
-iptables -t nat -A PREROUTING -j ISTIO_REDIRECT                               -m comment --comment "istio/install-istio-prerouting"
+iptables -t nat -A PREROUTING -p tcp -j ENVOY_IN_REDIRECT                               -m comment --comment "envoy/install-envoy-inbound-prerouting"
 
-# Create a new chain for selectively redirecting outbound packets to
-# Envoy.
-iptables -t nat -N ISTIO_OUTPUT                                               -m comment --comment "istio/common-output-chain"
+if [[ ! -z "${ENVOY_OUT_PORT-}" ]]; then
+    # Create a new chain for selectively redirecting outbound packets to Envoy port
+    iptables -t nat -N ENVOY_OUT_REDIRECT                                               -m comment --comment "envoy/redirect-outbound-chain"
 
-# Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp
-# traffic. '-j RETURN' bypasses Envoy and '-j ISTIO_REDIRECT'
-# redirects to Envoy.
-iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT                              -m comment --comment "istio/install-istio-output"
+    # Jump to the ENVOY_OUT_REDIRECT chain from OUTPUT chain for all tcp traffic.
+    # '-j RETURN' bypasses Envoy and '-j ENVOY_OUT_REDIRECT' redirects to Envoy.
+    iptables -t nat -A OUTPUT -p tcp -j ENVOY_OUT_REDIRECT                              -m comment --comment "envoy/install-envoy-out-redirect"
 
-# Redirect app calls to back itself via Envoy when using the service VIP or endpoint
-# address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT     -m comment --comment "istio/redirect-implicit-loopback"
+    # Redirect app calls back to itself via Envoy when using the service VIP or
+    # endpoint address, e.g. appN => Envoy (client) => Envoy (server) => appN.
+    iptables -t nat -A ENVOY_OUT_REDIRECT -o lo ! -d 127.0.0.1/32 -j ENVOY_IN_REDIRECT  -m comment --comment "envoy/redirect-implicit-loopback"
 
-# Avoid infinite loops. Don't redirect Envoy traffic directly back to
-# Envoy for non-loopback traffic.
-iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner ${ENVOY_UID} -j RETURN   -m comment --comment "istio/bypass-envoy"
+    # Avoid infinite loops. Don't redirect Envoy traffic directly back to Envoy for
+    # non-loopback traffic.
+    iptables -t nat -A ENVOY_OUT_REDIRECT -m owner --uid-owner ${ENVOY_UID} -j RETURN   -m comment --comment "envoy/outbound-bypass-envoy"
 
-# Skip redirection for Envoy-aware applications and
-# container-to-container traffic both of which explicitly use
-# localhost.
-iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN                     -m comment --comment "istio/bypass-explicit-loopback"
+    # Skip redirection for Envoy-aware applications and container-to-container
+    # traffic both of which explicitly use localhost.
+    iptables -t nat -A ENVOY_OUT_REDIRECT -d 127.0.0.1/32 -j RETURN                     -m comment --comment "envoy/bypass-explicit-loopback"
 
-# All outbound traffic will be redirected to Envoy by default. If
-# IP_RANGES_INCLUDE is non-empty, only traffic bound for the
-# destinations specified in this list will be captured.
-IFS=,
-if [ "${IP_RANGES_INCLUDE}" != "" ]; then
-    for cidr in ${IP_RANGES_INCLUDE}; do
-        iptables -t nat -A ISTIO_OUTPUT -d ${cidr} -j ISTIO_REDIRECT          -m comment --comment "istio/redirect-ip-range-${cidr}"
-    done
-    iptables -t nat -A ISTIO_OUTPUT -j RETURN                                 -m comment --comment "istio/bypass-default-outbound"
-else
-    iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT                         -m comment --comment "istio/redirect-default-outbound"
-    #iptables -t nat -A ISTIO_OUTPUT -j RETURN                                 -m comment --comment "istio/bypass-default-outbound"
+    # All outbound traffic will be redirected to Envoy by default. If
+    # IP_RANGES_INCLUDE is non-empty, only traffic bound for the destinations
+    # specified in this list will be captured.
+    IFS=,
+    if [ "${IP_RANGES_INCLUDE}" != "" ]; then
+        for cidr in ${IP_RANGES_INCLUDE}; do
+            iptables -t nat -A ENVOY_OUT_REDIRECT -d ${cidr} -p tcp -j REDIRECT --to-port ${ENVOY_OUT_PORT}    -m comment --comment "envoy/redirect-ip-range-${cidr}"
+        done
+        iptables -t nat -A ENVOY_OUT_REDIRECT -p tcp -j RETURN                                                 -m comment --comment "envoy/bypass-default-outbound"
+    else
+        iptables -t nat -A ENVOY_OUT_REDIRECT -p tcp -j REDIRECT --to-port ${ENVOY_OUT_PORT}                   -m comment --comment "envoy/redirect-default-outbound"
+        #iptables -t nat -A ENVOY_OUT_REDIRECT -p tcp -j RETURN                                                 -m comment --comment "envoy/bypass-default-outbound"
+    fi
 fi
-
 
 exit 0


### PR DESCRIPTION
- introduce an optional parameter to redirect all outbound packets to a different envoy listener port
- the outbound parameter defaults to inbound port when not specified