### PR TITLE
Make the Kafka Authorizer compilable under Java 11

### DIFF
--- a/kafka_authorizer/pom.xml
+++ b/kafka_authorizer/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.20</version>
+      <version>1.18.12</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Th Kafka Authorizer currently doesn't compile under Java 11 because of too old version of the Lombok dependency. This PR bumps the Lombok version to fix this. It still works with Java 8 and Java 8 as source and target versions, just makes it compile under Java 11 as well.