### PR TITLE
Add authentication token to the README.md file

### DIFF
--- a/kafka_authorizer/README.md
+++ b/kafka_authorizer/README.md
@@ -35,6 +35,7 @@ The plugin supports the following properties:
 | `opa.authorizer.cache.initial.capacity` | `100` | Initial decision cache size. |
 | `opa.authorizer.cache.maximum.size` | `100` | Max decision cache size. |
 | `opa.authorizer.cache.expire.after.ms` | `600000` | Decision cache expiry in milliseconds. |
+| `opa.authorizer.token` | `` | Token for authentication with OPA. |
 
 ## Usage
 


### PR DESCRIPTION
This PR adds the `opa.authorizer.token` option to the README.md file to make it easy to find without looking into the source codes.