### PR TITLE
Fix elastic search installation URL

### DIFF
--- a/data_filter_elasticsearch/README.md
+++ b/data_filter_elasticsearch/README.md
@@ -13,7 +13,7 @@ Build the example by running `make build`
 
 ## Running the example
 
-1. Run Elasticsearch. See Elasticsearch's [Installation](https://www.elastic.co/guide/en/elasticsearch/reference/current/_installation.html) to get started.
+1. Run Elasticsearch. See Elasticsearch's [Installation](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html) to get started.
 
 2. Open a new window and start the example server:
 


### PR DESCRIPTION
The installation steps to elastic search isn't working. So updated to the latest installation home page of ES.
fixes: #110 
Signed-off-by: Vineeth Pothulapati <vineethpothulapati@outlook.com>
cc @ashutosh-narkar 