### PR TITLE
envoy_iptables: Add port whitelist to bypass envoy

### DIFF
--- a/envoy_iptables/Makefile
+++ b/envoy_iptables/Makefile
@@ -1,5 +1,5 @@
 REPOSITORY := openpolicyagent/proxy_init
-VERSION := v4
+VERSION := v5
 
 .PHONY: all
 all: image

--- a/envoy_iptables/README.md
+++ b/envoy_iptables/README.md
@@ -3,3 +3,7 @@
 This directory contains the Istio proxy init script and a Dockerfile for
 building an image for the init container that installs iptables rules to
 redirect all container traffic through the Envoy proxy sidecar.
+
+Ports can be whitelisted to bypass the envoy proxy by using the `-w`
+parameter with a comma separated list of ports. This is useful for
+application health checks that should go directly to a service.


### PR DESCRIPTION
This updates the script to have a new parameter `-w` which accepts a
comma separated list of ports. Inbound traffic for these ports will
be configured to bypass the envoy proxy by `RETURN`ing early in the
`ENVOY_IN_REDIRECT` chain.

By default there are no open ports, thus the change is backwards
compatible.

Any users of the OPA+Envoy integration that want to use a health check
on a separate port (using `--diagnostic-addr`) will likely need to
update their deployments to use this new flag.

Signed-off-by: Patrick East <east.patrick@gmail.com>