### PR TITLE
Resolve #42. Changing the print statement to function

### DIFF
--- a/data_filter_azure/data_filter_azure/opa.py
+++ b/data_filter_azure/data_filter_azure/opa.py
@@ -59,7 +59,7 @@ unconditionally. In this case, the `defined` attribute will be True but the
 >>> result = opa.compile(q='data.example.allow==true', input={'method':'GET', 'path': ['deadbeef'], 'user': 'bob'}, unknowns=['posts'])
 >>> result.defined
 True
->>> print result.sql
+>>> print(result.sql)
 None
 """
 

--- a/data_filter_azure/data_filter_azure/sql.py
+++ b/data_filter_azure/data_filter_azure/sql.py
@@ -131,7 +131,7 @@ def pretty_print(node):
             self.indent = indent
 
         def __call__(self, node):
-            print ' ' * self.indent, node.__class__.__name__
+            print(' ' * self.indent, node.__class__.__name__)
             return printer(self.indent + 2)
 
     vis = printer(0)

--- a/data_filter_example/data_filter_example/opa.py
+++ b/data_filter_example/data_filter_example/opa.py
@@ -59,7 +59,7 @@ unconditionally. In this case, the `defined` attribute will be True but the
 >>> result = opa.compile(q='data.example.allow==true', input={'method':'GET', 'path': ['deadbeef'], 'user': 'bob'}, unknowns=['posts'])
 >>> result.defined
 True
->>> print result.sql
+>>> print(result.sql)
 None
 """
 

--- a/data_filter_example/data_filter_example/server.py
+++ b/data_filter_example/data_filter_example/server.py
@@ -180,7 +180,7 @@ def insert_object(table, cursor, obj):
     values = '(' + ','.join(['?'] * len(row_keys)) + ')'
     stmt = 'INSERT INTO {} {} VALUES {}'.format(table, keys, values)
     args = [str(obj[k]) for k in row_keys]
-    print str(stmt), args
+    print(str(stmt), args)
     cursor.execute(stmt, args)
 
 

--- a/data_filter_example/data_filter_example/sql.py
+++ b/data_filter_example/data_filter_example/sql.py
@@ -123,7 +123,7 @@ def pretty_print(node):
             self.indent = indent
 
         def __call__(self, node):
-            print ' ' * self.indent, node.__class__.__name__
+            print(' ' * self.indent, node.__class__.__name__)
             return printer(self.indent + 2)
 
     vis = printer(0)


### PR DESCRIPTION
> One of the changes from Python 2 to Python 3 was PEP 3105, which changes the convention of print to be a called function, which requires the use of parenthesis. These have not yet been changed across the whole codebase.

Changes according to the comment