### PR TITLE
add flux interval example

### DIFF
--- a/flux_intervals_example/Makefile
+++ b/flux_intervals_example/Makefile
@@ -1,0 +1,6 @@
+POLICIES    := policies
+OPA_IMAGE   := openpolicyagent/opa
+OPA_VERSION := 0.23.2
+
+test:
+	docker run --rm -v $$(PWD)/$(POLICIES):/tmp $(OPA_IMAGE):$(OPA_VERSION) test /tmp -v

--- a/flux_intervals_example/README.md
+++ b/flux_intervals_example/README.md
@@ -1,0 +1,22 @@
+# Flux Intervals Enforcement Example
+
+This example demonstrates how to ensure consumers of your kubernetes cluster don't slam your cluster's API or git repositories by configuring [flux](https://fluxcd.io/) to sync too frequently.
+
+Policies for enforcing flux argument values are in the [policies directory](./policies)
+
+## Arguments checked
+
+[Flux arguments documentation](https://docs.fluxcd.io/en/latest/references/daemon/)
+
+- `--git-poll-interval`
+  - Ensure at least set to `10m`
+- `--sync-interval`
+  - Ensure at least set to `10m`
+
+## Test
+
+```bash
+make test
+```
+
+> Requires docker

--- a/flux_intervals_example/policies/flux.rego
+++ b/flux_intervals_example/policies/flux.rego
@@ -1,0 +1,27 @@
+package kubernetes.validating.flux
+
+image := "fluxcd/flux"
+
+deny[msg] {
+    # Ensure only applies to flux images
+    containerImage := input.spec.template.spec.containers[i].image
+    contains(containerImage, image)
+    # Check if git poll interval arg is present
+    args := input.spec.template.spec.containers[_].args
+    contains(args[_], "--git-poll-interval")
+    # If single digit is present, deny
+    regex.match("--git-poll-interval=[0-9]m", args[_])
+    msg := "--git-poll-interval must be at least 10m"
+}
+
+deny[msg] {
+    # Ensure only applies to flux images
+    containerImage := input.spec.template.spec.containers[i].image
+    contains(containerImage, image)
+    # Check if sync interval arg is present
+    args := input.spec.template.spec.containers[_].args
+    contains(args[_], "--sync-interval")
+    # If single digit is present, deny
+    regex.match("--sync-interval=[0-9]m", args[_])
+    msg := "--sync-interval must be at least 10m"
+}

--- a/flux_intervals_example/policies/flux_test.rego
+++ b/flux_intervals_example/policies/flux_test.rego
@@ -1,0 +1,21 @@
+package kubernetes.validating.flux
+
+test_ten_minutes_allowed {
+    count(deny) == 0 with input as {"spec":{"template":{"spec":{"containers":[{"image":"fluxcd/flux:1.20.2","args":["--git-poll-interval=10m","--sync-interval=10m"]}]}}}}
+}
+
+test_one_hour_allowed {
+    count(deny) == 0 with input as {"spec":{"template":{"spec":{"containers":[{"image":"fluxcd/flux:1.20.2","args":["--git-poll-interval=1h","--sync-interval=1h"]}]}}}}
+}
+
+test_five_minutes_denied{
+    deny with input as {"spec":{"template":{"spec":{"containers":[{"image":"fluxcd/flux:1.20.2","args":["--git-poll-interval=5m","--sync-interval=5m"]}]}}}}
+}
+
+test_five_minutes_denied_git_poll {
+    count(deny) == 1 with input as {"spec":{"template":{"spec":{"containers":[{"image":"fluxcd/flux:1.20.2","args":["--git-poll-interval=5m","--sync-interval=10m"]}]}}}}
+}
+
+test_five_minutes_denied_sync_interval {
+    count(deny) == 1 with input as {"spec":{"template":{"spec":{"containers":[{"image":"fluxcd/flux:1.20.2","args":["--git-poll-interval=10m","--sync-interval=5m"]}]}}}}
+}


### PR DESCRIPTION
This example demonstrates how to ensure consumers of a kubernetes cluster don't slam a cluster's API or some git repositories by configuring [flux](https://fluxcd.io/) to sync too frequently. The example also shows how one would enforce argument values in a deployment spec.