### PR TITLE
data_filter_azure: Fix build to pin azure-storage dependency

### DIFF
--- a/data_filter_azure/requirements.txt
+++ b/data_filter_azure/requirements.txt
@@ -3,5 +3,5 @@ flask
 Flask-Bootstrap
 git+git://github.com/open-policy-agent/rego-python@master
 pytest
-azure-storage >= 0.34.3
-azure-cosmos 
+azure-storage == 0.34.3
+azure-cosmos


### PR DESCRIPTION
The azure-storage package has been deprecated so the build needs to
pin to the original version from requirements.txt.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>