### PR TITLE
Kubernetes authorization webhook

### DIFF
--- a/k8s_authorization/Makefile
+++ b/k8s_authorization/Makefile
@@ -1,0 +1,14 @@
+.PHONY: deploy
+deploy:
+	./setup.sh
+
+.PHONY: test
+test:
+	./test.sh
+
+.PHONY: cleanup
+cleanup:
+	kind delete cluster --name opa-authorizer
+
+.PHONY: build
+build: deploy test cleanup

--- a/k8s_authorization/README.md
+++ b/k8s_authorization/README.md
@@ -1,0 +1,72 @@
+# Kubernetes authorization webhook using OPA
+
+Runnable Kubernetes
+[authorization webhook](https://kubernetes.io/docs/reference/access-authn-authz/webhook/)
+example using OPA for authorization policy decisions.
+
+## Running
+
+### Prerequisites
+
+* [kind](https://kind.sigs.k8s.io/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+### Setup
+
+With those installed, simply run:
+
+```shell
+./setup.sh
+```
+
+The demo uses [Kind](https://kind.sigs.k8s.io/) to launch a local Kubernetes
+cluster and then deploys OPA to that, with Kubernetes authorization policies
+deployed from the [policy](policy) directory. Kind uses kubeadm so that's the
+config format used for providing the authorization webhook flags to the API
+server (see [kind-conf.yaml](#kind-conf.yaml).
+
+### Testing the auhtorization webhook
+
+With the cluster up and running, you may now issue the usual `kubectl` commands
+to interact with your local Kubernetes API. Since the default user for kind is a
+cluster admin with all priveleges granted it won't autmoatically be evaluated by
+the authorizer webhook (as the RBAC module is configured in front of it). In
+order to work around this, you could either setup a service account - or perhaps
+easier; just simulate requests from other users by using the
+[impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation)
+feature of kubectl:
+
+```shell
+$ kubectl get pods \
+        --namespace kube-system \
+        --as=someuser \
+        --as-group=system:authenticated \
+        --as-group=devops
+
+Error from server (Forbidden): OPA: denied access to namespace kube-system
+```
+
+The OPA server is configured to print decisions to stdout, so simply view the logs
+of the OPA pod (in the `opa` namespace) to see requests and responses.
+
+## Updating policy
+
+Change the policy under the policy directory and run `kubectl apply -k .` Note
+that it may take a while before the policy change is reflected in the running
+system.
+
+## Tests
+
+There's a couple of end-to-end tests using kubectl to test authorization policy
+enforcement in the `test.sh` script. Simply run it to have them executed:
+
+```shell
+$ ./test.sh
+All tests successful
+```
+
+## Cleanup
+
+```shell
+kind delete cluster --name opa-authorizer
+```

--- a/k8s_authorization/api-server/authz-webhook.yaml
+++ b/k8s_authorization/api-server/authz-webhook.yaml
@@ -1,0 +1,21 @@
+clusters:
+- name: opa
+  cluster:
+    # For the purpose of the demo we use a self-signed certificate.
+    # This should obviously be changed for production purposes.
+    insecure-skip-tls-verify: true
+    # Use static IP configured for service as the kubernetes DNS service (CoreDNS)
+    # can't be used by the API server (as that would be a circular dependency).
+    server: https://10.96.167.0/v0/data/k8s/authz/decision
+users:
+- name: api-server
+  user:
+    # Authentication method to use for accessing OPA itself
+    # See https://www.openpolicyagent.org/docs/latest/security/#authentication-and-authorization
+    token: test-token
+current-context: webhook
+contexts:
+- context:
+    cluster: opa
+    user: api-server
+  name: webhook

--- a/k8s_authorization/config/kind-conf.yaml
+++ b/k8s_authorization/config/kind-conf.yaml
@@ -1,0 +1,21 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: ${pwd}/api-server
+    containerPath: /etc/kubernetes/api-server
+- role: worker
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  apiServer:
+    extraVolumes:
+    - name: api-server
+      hostPath: /etc/kubernetes/api-server
+      mountPath: /etc/kubernetes/api-server
+    extraArgs:
+      authorization-mode: Node,RBAC,Webhook
+      authorization-webhook-version: v1
+      authorization-webhook-config-file: /etc/kubernetes/api-server/authz-webhook.yaml
+      feature-gates: "EphemeralContainers=true"

--- a/k8s_authorization/kubernetes/resources.yaml
+++ b/k8s_authorization/kubernetes/resources.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opa-authz-webhook
+  namespace: opa
+  labels:
+    app: opa
+spec:
+  clusterIP: 10.96.167.0
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: opa
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: opa
+  namespace: opa
+  labels:
+    app: opa
+spec:
+  selector:
+    matchLabels:
+      app: opa
+  template:
+    metadata:
+      labels:
+        app: opa
+    spec:
+      volumes:
+        - name: cert-volume
+          emptyDir: {}
+        - name: policy-volume
+          configMap:
+            name: opa-k8s-authz-policy
+      initContainers:
+        - name: cert-create
+          image: frapsoft/openssl:latest
+          args: [
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:4096",
+            "-keyout",
+            "/certs/key.pem",
+            "-out",
+            "/certs/cert.pem",
+            "-nodes",
+            "-days",
+            "365",
+            "-subj",
+            "/C=SE/ST=Stockholm/L=Stockholm/O=Styra/OU=Org/CN=10.96.167.0"
+          ]
+          volumeMounts:
+            - mountPath: /certs
+              name: cert-volume
+      containers:
+        - name: opa
+          image: openpolicyagent/opa:0.26.0-rootless
+          ports:
+            - containerPort: 8443
+          args:
+            [
+              "run",
+              "--server",
+              "--ignore=.*",
+              "--addr=:8443",
+              "--log-level=error",
+              "--log-format=json-pretty",
+              "--shutdown-grace-period=25",
+              "--shutdown-wait-period=10",
+              "--set=caching.inter_query_builtin_cache.max_size_bytes=128000000",
+              "--set=decision_logs.console=true",
+              "--tls-cert-file=/certs/cert.pem",
+              "--tls-private-key-file=/certs/key.pem",
+              "/policy/"
+            ]
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "125m"
+            limits:
+              memory: "256Mi"
+              cpu: "700m"
+          env:
+            - name: APP_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app']
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 12000
+            runAsGroup: 12000
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
+          volumeMounts:
+            - mountPath: /certs
+              name: cert-volume
+            - mountPath: /policy
+              name: policy-volume
+      enableServiceLinks: false
+      # Run only on the master nodes (with the API server)
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: ""

--- a/k8s_authorization/kustomization.yaml
+++ b/k8s_authorization/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- kubernetes/resources.yaml
+
+configMapGenerator:
+- name: opa-k8s-authz-policy
+  namespace: opa
+  files:
+  - policy/policy.rego

--- a/k8s_authorization/policy/policy.rego
+++ b/k8s_authorization/policy/policy.rego
@@ -1,0 +1,38 @@
+package k8s.authz
+
+deny[reason] {
+	input.spec.resourceAttributes.namespace == "kube-system"
+
+	reason := "OPA: denied access to namespace kube-system"
+}
+
+deny[reason] {
+	input.spec.resourceAttributes.namespace == "opa"
+
+	required_groups := {"system:authenticated", "devops"}
+	provided_groups := {group | group := input.spec[groups][_]}
+
+	count(required_groups & provided_groups) != count(required_groups)
+
+	reason := sprintf("OPA: provided groups (%v) does not include all required groups: (%v)", [
+		concat(", ", provided_groups),
+		concat(", ", required_groups),
+	])
+}
+
+decision = {
+	"apiVersion": input.apiVersion,
+	"kind": "SubjectAccessReview",
+	"status": {
+		"allowed": count(deny) == 0,
+		"reason": concat(" | ", deny),
+	},
+}
+
+# Take into account the typo of missing "s" in groups
+# in v1beta1 version (which is used by default)
+# https://github.com/kubernetes/kubernetes/issues/32709
+groups = {
+	"authorization.k8s.io/v1": "groups",
+	"authorization.k8s.io/v1beta1": "group",
+}[input.apiVersion]

--- a/k8s_authorization/setup.sh
+++ b/k8s_authorization/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+k() {
+    kubectl --context kind-opa-authorizer "$@"
+}
+
+pwd=$(pwd) envsubst < config/kind-conf.yaml | kind create cluster --name opa-authorizer --config -
+
+k create namespace opa
+k apply -k .

--- a/k8s_authorization/test.sh
+++ b/k8s_authorization/test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+k() {
+    kubectl --context kind-opa-authorizer "$@"
+}
+
+expect() {
+    if [[ "$1" != "$2" ]]; then
+        echo "Expected $1 == $2"
+        exit 1
+    fi
+}
+
+expect_ends_with() {
+    if [[ "$1" != *"$2" ]]; then
+        echo "Expected $1 == *$2"
+        exit 1
+    fi
+}
+
+echo "Waiting for OPA pod to come up"
+
+exit_code=1
+retries=0
+opa_pod=""
+
+while [[ "$exit_code" != 0 && "$retries" -lt 20 ]]
+do
+    sleep 5
+    opa_pod=$(k --namespace opa get pods -l app=opa -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    exit_code="$?"
+    ((retries++))
+done
+
+echo "OPA pod is up - awaiting condition=Ready"
+
+# Wait for the OPA pod to become ready
+k --namespace opa wait --for=condition=Ready --timeout=100s pods/"$opa_pod" > /dev/null
+
+echo "OPA pod ready. Running tests."
+echo "============================="
+
+# Access to kube-system should be denied
+result=$(k --namespace kube-system --as=someuser --as-group=system:authenticated get pods 2>&1)
+expect "$?" 1
+expect_ends_with "$result" "OPA: denied access to namespace kube-system"
+
+# Access to opa namespace denied unless in devops group
+result=$(k --namespace opa --as=someuser --as-group=system:authenticated get pods 2>&1)
+expect "$?" 1
+expect_ends_with "$result" "OPA: provided groups (system:authenticated) does not include all required groups: (devops, system:authenticated)"
+
+# Access to opa namespace allowed if in devops group
+result=$(k --namespace opa --as=someuser --as-group=system:authenticated --as-group=devops get pods 2>&1)
+expect "$?" 0
+
+echo "All tests successful!"


### PR DESCRIPTION
Add example project demonstrating kubernetes webhook authorization using OPA.
Since most of the complexities with kubernetes authorization webhooks are not
about the actual authorization policies but rather about how to properly
configure kubernetes, this project uses kind to launch a local cluster for
testing.

To be followed up with a blog post going into the details of the configuration
and the caveats one needs to consider for this type of setup.

Signed-off-by: Anders Eknert <anders@eknert.com>