### PR TITLE
Add --quiet flag to kafka build

### DIFF
--- a/kafka_authorizer/scripts/build.sh
+++ b/kafka_authorizer/scripts/build.sh
@@ -2,4 +2,4 @@
 
 DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
-docker run -w /src -v $DIR/..:/src maven:3.5.3-jdk-8 mvn install
+docker run -w /src -v $DIR/..:/src maven:3.5.3-jdk-8 mvn --quiet install


### PR DESCRIPTION
Was printing thousands of lines in the build output.
With --quiet will only print errors.

Signed-off-by: Anders Eknert <anders@eknert.com>