### PR TITLE
Bump insecure Spring dependencies

### DIFF
--- a/spring_authz/.gitignore
+++ b/spring_authz/.gitignore
@@ -3,6 +3,9 @@
 .settings
 .project
 .classpath
+.idea
+
+*.iml
 
 target
 

--- a/spring_authz/pom.xml
+++ b/spring_authz/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openpolicyagent</groupId>
   <artifactId>voter</artifactId>
@@ -7,39 +7,40 @@
   <version>1.0-SNAPSHOT</version>
   <name>voter</name>
 
-   <properties>
-    <java.version>1.8</java.version>
+  <properties>
+    <java.version>1.11</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.4.RELEASE</version>
+      <version>5.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.4.RELEASE</version>
+      <version>5.5.0</version>
     </dependency>
   </dependencies>
 
   <build>
-      <plugins>
-          <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-      </plugins>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/spring_authz/src/main/java/org/openpolicyagent/voter/OPADataRequest.java
+++ b/spring_authz/src/main/java/org/openpolicyagent/voter/OPADataRequest.java
@@ -10,6 +10,7 @@ public class OPADataRequest {
         this.input = input;
     }
 
+    @SuppressWarnings("unused")
     public Map<String, Object> getInput() {
         return this.input;
     }

--- a/spring_authz/src/main/java/org/openpolicyagent/voter/OPADataResponse.java
+++ b/spring_authz/src/main/java/org/openpolicyagent/voter/OPADataResponse.java
@@ -12,6 +12,7 @@ public class OPADataResponse {
         return this.result;
     }
 
+    @SuppressWarnings("unused")
     public void setResult(boolean result) {
         this.result = result;
     }

--- a/spring_authz/src/main/java/org/openpolicyagent/voter/OPAVoter.java
+++ b/spring_authz/src/main/java/org/openpolicyagent/voter/OPAVoter.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.RestTemplate;
 
 public class OPAVoter implements AccessDecisionVoter<Object> {
 
-    private String opaUrl;
+    private final String opaUrl;
 
     public OPAVoter(String opaUrl) {
         this.opaUrl = opaUrl;
@@ -38,7 +38,7 @@ public class OPAVoter implements AccessDecisionVoter<Object> {
         }
 
         FilterInvocation filter = (FilterInvocation) obj;
-        Map<String, String> headers = new HashMap<String, String>();
+        Map<String, String> headers = new HashMap<>();
 
         for (Enumeration<String> headerNames = filter.getRequest().getHeaderNames(); headerNames.hasMoreElements();) {
             String header = headerNames.nextElement();
@@ -47,7 +47,7 @@ public class OPAVoter implements AccessDecisionVoter<Object> {
 
         String[] path = filter.getRequest().getRequestURI().replaceAll("^/|/$", "").split("/");
 
-        Map<String, Object> input = new HashMap<String, Object>();
+        Map<String, Object> input = new HashMap<>();
         input.put("auth", authentication);
         input.put("method", filter.getRequest().getMethod());
         input.put("path", path);
@@ -57,7 +57,7 @@ public class OPAVoter implements AccessDecisionVoter<Object> {
         HttpEntity<?> request = new HttpEntity<>(new OPADataRequest(input));
         OPADataResponse response = client.postForObject(this.opaUrl, request, OPADataResponse.class);
 
-        if (!response.getResult()) {
+        if (response == null || !response.getResult()) {
             return ACCESS_DENIED;
         }
 


### PR DESCRIPTION
While at it:

- Bump Java to version 11.
- Bump all other dependencies to their latest versions.
- Fix Maven warnings.
- Avoid possible NPE.

Signed-off-by: Anders Eknert <anders@eknert.com>