### PR TITLE
kong_api_authz: Fix error when no JWT token is provided

### DIFF
--- a/kong_api_authz/src/kong/plugins/opa/access.lua
+++ b/kong_api_authz/src/kong/plugins/opa/access.lua
@@ -75,7 +75,7 @@ function _M.execute(conf)
     kong.log.debug(interp("Access allowed to ${method} ${path} for user ${subject}", {
         method = input.method,
         path = input.path,
-        subject = token.payload.sub
+        subject = (token.payload and token.payload.sub or 'anonymous')
     }))
 end
 


### PR DESCRIPTION
When no token is provided with the request, the execution fail the attempt to index the field 'payload' (a nil value).
In case the subject from the JWT token is not be defined or there's no token, 'anonymous' will be used instead.

Fixes open-policy-agent/contrib#146