### PR TITLE
Include request body as an input to PUT /v1/data/{path}

### DIFF
--- a/open_api/openapi.yaml
+++ b/open_api/openapi.yaml
@@ -227,6 +227,13 @@ paths:
 
         This behavior is similar to the Unix command [mkdir -p](https://en.wikipedia.org/wiki/Mkdir#Options).
       operationId: putDocument
+      requestBody:
+        description: The JSON document to write to the specified path.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/dataSchema'
       parameters:
         - $ref: '#/components/parameters/ifNoneMatchParameter'
       tags:
@@ -803,6 +810,15 @@ components:
                }
              }
            }
+    dataSchema:
+      example: |-
+        {
+          "users": {
+            "user-id-1": {
+              "isAdmin": true
+            }
+          }
+        }
     webhookInputSchema:
       type: object
       example: |-


### PR DESCRIPTION
I was going off the REST API docs on openpolicyagent.org [here](https://www.openpolicyagent.org/docs/v0.36.1/rest-api/#create-or-overwrite-a-document) and confirmed that this API seems to take a request body

Example request from that link:

> ```
> PUT /v1/data/us-west/servers HTTP/1.1
> Content-Type: application/json
> If-None-Match: *
>
> {}
> ```

I confirmed that [this part of the server implementation looks at the request body](https://github.com/open-policy-agent/opa/blob/829086a2e04da57d0b4e76008fbe6ac825c7929e/server/server.go#L1675)

and then verified it on a local OPA server (version `0.34.2`)

```
curl -XPUT -H'content-type: application/json' localhost:8181/v1/data/foo -d '{"foo": true}'
curl localhost:8181/v1/data/foo
```
outputs
```
{"result":{"foo":true}}
```

# JSON Schema

I specifically didn't write a JSON schema (even the `type` key) because the docs and the code don't seem to require that. E.g. you could push an array to `foo/bar` that's just a string or an array or something.

# Testing

I tested this by regenerating my openapi client (TypeScript) from this branch, and here's the diff of the relevant method
```diff
--- a/old
+++ b/new
@@ -9,10 +9,13 @@
      */
     public static putDocument({
         path,
+        requestBody,
         ifNoneMatch,
     }: {
         /** A backslash (/) delimited path to access values inside object and array documents. If the path points to an array, the server will attempt to convert the array index to an integer. If the path element cannot be converted to an integer, the server will respond with 404. **/
         path: string,
+        /** The JSON document to write to the specified path. **/
+        requestBody: dataSchema,
         /** The server will respect the If-None-Match header if it is set to * (in other words, it will not overwrite an existing document located at the specified `path`). **/
         ifNoneMatch?: string,
     }): CancelablePromise<void> {
@@ -22,6 +25,8 @@
             headers: {
                 'If-None-Match': ifNoneMatch,
             },
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 304: `Document was not modified`,
                 400: `Bad request`,
```