### PR TITLE
build: disable gatekeeper_mtail_violations_exporter

### DIFF
--- a/build/make-all.sh
+++ b/build/make-all.sh
@@ -29,7 +29,7 @@ for file in ${CONTRIB_ROOT}/*/Makefile; do
     base=$(basename "$dir")
 
     # TODO: Fix these two currently failing GH actions builds
-    if [ "$base" == "data_filter_mongodb" ] || [ "$base" == "data_filter_example" ]; then
+    if [ "$base" == "gatekeeper_mtail_violations_exporter" ] || [ "$base" == "data_filter_mongodb" ] || [ "$base" == "data_filter_example" ]; then
         continue
     fi
 


### PR DESCRIPTION
Because the build for gatekeeper_mtail_violations_exporter is broken,
disable it for the time being.

Potential fix: https://github.com/open-policy-agent/contrib/pull/166#issuecomment-1087686778

Signed-off-by: Charles Daniels <charles@styra.com>