### PR TITLE
build: disable pam_opa

### DIFF
--- a/build/make-all.sh
+++ b/build/make-all.sh
@@ -29,7 +29,7 @@ for file in ${CONTRIB_ROOT}/*/Makefile; do
     base=$(basename "$dir")
 
     # TODO: Fix these two currently failing GH actions builds
-    if [ "$base" == "gatekeeper_mtail_violations_exporter" ] || [ "$base" == "data_filter_mongodb" ] || [ "$base" == "data_filter_example" ]; then
+    if [ "$base" == "pam_opa" ] || [ "$base" == "gatekeeper_mtail_violations_exporter" ] || [ "$base" == "data_filter_mongodb" ] || [ "$base" == "data_filter_example" ]; then
         continue
     fi
 


### PR DESCRIPTION
I am able to build pam_opa locally, however in GitHub Actions, the build
is failing due to the error:

	ERROR: The certificate of 'www.digip.org' is not trusted.

Signed-off-by: Charles Daniels <charles@styra.com>