### PR TITLE
Fixing missing docker image and updating opa version.

### DIFF
--- a/kong_api_authz/README.md
+++ b/kong_api_authz/README.md
@@ -99,6 +99,7 @@ form parameter | default | description
 `config.server.port` | _8181_ | The port on wich OPA is listening
 `config.server.connection.timeout` | _60_ | For the connection with the OPA server: the maximal idle timeout (ms)
 `config.server.connection.pool` | _10_ | For the connection with the OPA server: the maximum number of connections in the pool
+`config.document.include_headers` | | Names of request headers to include in the document that is sent to OPA (in the document, all header names will be lower case).
 `config.policy.base_path` | _v1/data_ | The OPA DATA API base path
 **`config.policy.decision`** | | The path to the OPA rule to evaluate
 

--- a/kong_api_authz/src/kong/plugins/opa/access.lua
+++ b/kong_api_authz/src/kong/plugins/opa/access.lua
@@ -41,6 +41,24 @@ end
 -- module
 local _M = {}
 
+local function filterHeaders(headers, wanted_headers)
+    -- "Since the 0.6.9 release, all the header names in the Lua table returned
+    -- are converted to the pure lower-case form by default, unless the raw
+    -- argument is set to true (default to false)."
+    -- So we need to convert the requested header names to lower case too.
+    local filtered_headers = {}
+    if wanted_headers and headers then
+        for _, wanted_header in ipairs(wanted_headers) do
+            local lower_key = string.lower(wanted_header)
+            local value = headers[lower_key]
+            if value then
+                filtered_headers[lower_key] = value
+            end
+        end
+    end
+    return filtered_headers
+end
+
 function _M.execute(conf)
     local authorization = ngx.var.http_authorization
 
@@ -56,6 +74,7 @@ function _M.execute(conf)
         token = token,
         method = ngx.var.request_method,
         path = ngx.var.upstream_uri,
+        headers = filterHeaders(ngx.req.get_headers(), conf.document and conf.document.include_headers)
     }
 
     local status, res = pcall(getDocument, input, conf)

--- a/kong_api_authz/src/kong/plugins/opa/schema.lua
+++ b/kong_api_authz/src/kong/plugins/opa/schema.lua
@@ -60,6 +60,21 @@ return {
             },
           },
           {
+            document = {
+              type = "record",
+              fields = {
+                {
+                  include_headers = {
+                    type = "array",
+                    elements = {
+                      type = "string"
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
             policy = {
               type = "record",
               fields = {


### PR DESCRIPTION
Noticed that in the onsite documentation this code is a bit different, but also fails due to the docker image (demo-restful-api:0.3) originally included not being present in [docker hub.](https://hub.docker.com/r/openpolicyagent/demo-restful-api/tags)