### PR TITLE
Upgrade base image proxy_init

### DIFF
--- a/envoy_iptables/Dockerfile
+++ b/envoy_iptables/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
 ADD ./proxy_init.sh /proxy_init.sh
 RUN chmod 755 /proxy_init.sh


### PR DESCRIPTION
The proxy_init script is based off an ubuntu base, upgrade to ubuntu:focal. @vinhph0906 
Signed-off-by: minhlhd <minhlhd@vng.com.vn>

