### PR TITLE
dependabot: update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
We've been getting a few save-state and set-output warnings, those should go away with updating some actions.
