### PR TITLE
Support for configurable connect/send/read timeout on OPA HTTP connection in kong_api_authz module.

### DIFF
--- a/kong_api_authz/README.md
+++ b/kong_api_authz/README.md
@@ -92,16 +92,19 @@ Here's a list of all the parameters which can be used in this plugin's configura
 
 > _required fields are in bold_
 
-form parameter | default | description
---- | --- | ---
-`config.server.protocol` | _http_ | The communication protocol to use with OPA Server (`http` or `https`)
+form parameter | default     | description
+--- |-------------| ---
+`config.server.protocol` | _http_      | The communication protocol to use with OPA Server (`http` or `https`)
 `config.server.host` | _localhost_ | The OPA DNS or IP address
-`config.server.port` | _8181_ | The port on wich OPA is listening
-`config.server.connection.timeout` | _60_ | For the connection with the OPA server: the maximal idle timeout (ms)
-`config.server.connection.pool` | _10_ | For the connection with the OPA server: the maximum number of connections in the pool
-`config.document.include_headers` | | Names of request headers to include in the document that is sent to OPA (in the document, all header names will be lower case).
-`config.policy.base_path` | _v1/data_ | The OPA DATA API base path
-**`config.policy.decision`** | | The path to the OPA rule to evaluate
+`config.server.port` | _8181_      | The port on wich OPA is listening
+`config.server.connection.timeout` | _60_        | For the connection with the OPA server: the maximum idle timeout (ms) before a pooled connection is closed
+`config.server.connection.pool` | _10_        | For the connection with the OPA server: the maximum number of connections in the pool
+`config.server.connection.connect_timeout` | _1000_      | For the connection with the OPA server: the maximum connect timeout (ms).  This applies to new connections that are not already pooled/open.
+`config.server.connection.send_timeout` | _1000_      | For the connection with the OPA server: the maximum send timeout (ms).  This can be a useful control to guard against excessive context information being sent to OPA as input.
+`config.server.connection.read_timeout` | _1000_      | For the connection with the OPA server: the maximum read timeout (ms).  This can be a useful control to guard against expensive OPA policies being used.
+`config.document.include_headers` |             | Names of request headers to include in the document that is sent to OPA (in the document, all header names will be lower case).
+`config.policy.base_path` | _v1/data_   | The OPA DATA API base path
+**`config.policy.decision`** |             | The path to the OPA rule to evaluate
 
 ---
 

--- a/kong_api_authz/integration/docker-compose.test.yml
+++ b/kong_api_authz/integration/docker-compose.test.yml
@@ -6,12 +6,13 @@ services:
     volumes:
       # Import postman collection, environment and `wait-for-` script
       - ./testdata/postman:/etc/newman:ro
-    entrypoint: ["/etc/newman/wait-for-services.sh", "kong:8001", "opa:8181", "httpbin:80"]
+    entrypoint: ["/etc/newman/wait-for-services.sh", "kong:8001", "opa:8181", "httpbin:80", "opa-proxy:8474"]
     command: ["run", "kong-plugin-opa.integration_tests.postman_collection.json", "-e", "docker.postman_environment.json"]
     depends_on: # will start only services required for integration tests
       - kong
       - opa
       - httpbin
+      - opa-proxy
 
   kong:
     volumes:
@@ -25,12 +26,26 @@ services:
   opa:
     working_dir: /bundle
     volumes:
-      # Load policies for tests 
+      # Load policies for tests
       - ./testdata/opa/bundle:/bundle:ro
     command: "run --server --bundle . --log-level debug --log-format text"
-  
+
   # Mock upstream service
   httpbin:
     image: kennethreitz/httpbin
     ports:
       - "80:80"
+
+  # proxy requests to OPA with toxiproxy to allow simulation of high latency call to OPA
+  opa-proxy:
+    image: ghcr.io/shopify/toxiproxy:2.5.0
+    command:
+      - "-host=0.0.0.0"
+      - "-config"
+      - "/config/toxiproxy.json"
+    depends_on:
+      - opa
+    ports:
+      - "8474:8474"
+    volumes:
+      - ./toxiproxy.json:/config/toxiproxy.json:ro

--- a/kong_api_authz/integration/testdata/kong-test.yml
+++ b/kong_api_authz/integration/testdata/kong-test.yml
@@ -7,7 +7,9 @@ services:
         - name: opa
           config:
             server:
-                host: opa
+                host: opa-proxy
+                connection:
+                  read_timeout: 10
             policy:
                 decision: httpapi/authz/allow
       routes:

--- a/kong_api_authz/integration/testdata/postman/docker.postman_environment.json
+++ b/kong_api_authz/integration/testdata/postman/docker.postman_environment.json
@@ -26,6 +26,16 @@
 			"key": "forbidden_role",
 			"value": "user",
 			"enabled": true
+		},
+		{
+			"key": "toxiproxy_host",
+			"value": "opa-proxy",
+			"enabled": true
+		},
+		{
+			"key": "toxiproxy_port",
+			"value": "8474",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/kong_api_authz/integration/testdata/postman/kong-plugin-opa.integration_tests.postman_collection.json
+++ b/kong_api_authz/integration/testdata/postman/kong-plugin-opa.integration_tests.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "73199a0d-207c-49f6-a940-287e31edd3de",
+		"_postman_id": "1b4d44e7-1e4d-4282-a7e1-2ff5750fa4a2",
 		"name": "kong-plugin-opa.integration_tests",
 		"description": "Collection of integration tests for the kong-plugins-opa.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -12,7 +12,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "c521e4b5-b2ca-43f9-a358-43c0b5e59d7d",
 						"exec": [
 							"pm.test(\"Status code is 403\", function () {\r",
 							"    pm.response.to.have.status(403);\r",
@@ -24,7 +23,6 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "c3bd7e6d-ecb7-4714-bdd5-42dc89289925",
 						"exec": [
 							""
 						],
@@ -66,7 +64,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "c521e4b5-b2ca-43f9-a358-43c0b5e59d7d",
 						"exec": [
 							"pm.test(\"Status code is 403\", function () {\r",
 							"    pm.response.to.have.status(403);\r",
@@ -78,7 +75,6 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "c3bd7e6d-ecb7-4714-bdd5-42dc89289925",
 						"exec": [
 							""
 						],
@@ -132,7 +128,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "c521e4b5-b2ca-43f9-a358-43c0b5e59d7d",
 						"exec": [
 							"pm.test(\"Status code is 200\", function () {\r",
 							"    pm.response.to.have.status(200);\r",
@@ -144,7 +139,6 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "c3bd7e6d-ecb7-4714-bdd5-42dc89289925",
 						"exec": [
 							"// Base 63 URL encoding ",
 							"// from https://www.jonathan-petitcolas.com/2014/11/27/creating-json-web-token-in-javascript.html",
@@ -234,7 +228,6 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "a4a4a5ff-dc29-48e3-a392-1cd5c8e3b254",
 						"exec": [
 							"pm.test(\"Status code is 403\", function () {\r",
 							"    pm.response.to.have.status(403);\r",
@@ -246,7 +239,6 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "2b9db012-dc62-44ee-9a18-4c6fd2e54b66",
 						"exec": [
 							"// Base 63 URL encoding ",
 							"// from https://www.jonathan-petitcolas.com/2014/11/27/creating-json-web-token-in-javascript.html",
@@ -329,13 +321,174 @@
 				"description": "Test the plugin with a Token that has a role not allowed to access the service"
 			},
 			"response": []
+		},
+		{
+			"name": "Add 100ms latency to OPA calls with toxiproxy",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Host",
+						"type": "text",
+						"value": "{{route_host}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"name\": \"opaLatencyToxic\",\n  \"type\": \"latency\",\n  \"stream\": \"downstream\",\n  \"toxicity\": 1,\n  \"attributes\": {\n    \"latency\": 100,\n    \"jitter\": 1\n  }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{toxiproxy_host}}:{{toxiproxy_port}}/proxies/opaProxy/toxics",
+					"protocol": "http",
+					"host": [
+						"{{toxiproxy_host}}"
+					],
+					"port": "{{toxiproxy_port}}",
+					"path": [
+						"proxies",
+						"opaProxy",
+						"toxics"
+					]
+				},
+				"description": "Add 100ms latency to OPA calls with toxiproxy"
+			},
+			"response": []
+		},
+		{
+			"name": "Test Bearer Token with Allowed Role but with 100ms added latency exceeding 10ms read timeout",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 500\", function () {\r",
+							"    pm.response.to.have.status(500);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Base 63 URL encoding ",
+							"// from https://www.jonathan-petitcolas.com/2014/11/27/creating-json-web-token-in-javascript.html",
+							"function base64url(source) {",
+							"",
+							"  // Encode in classical base64",
+							"  var encodedSource = CryptoJS.enc.Base64.stringify(source);",
+							"",
+							"  // Remove padding equal characters",
+							"  encodedSource = encodedSource.replace(/=+$/, '');",
+							"",
+							"  // Replace characters according to base64url specifications",
+							"  encodedSource = encodedSource.replace(/\\+/g, '-');",
+							"  encodedSource = encodedSource.replace(/\\//g, '_');",
+							"",
+							"  return encodedSource;",
+							"}",
+							"",
+							"// set algorithm & token type",
+							"var header = {",
+							"    \"alg\": \"HS256\",",
+							"    \"typ\": \"JWT\"",
+							"};",
+							"",
+							"// set data",
+							"var payload = {",
+							"  \"sub\": \"1234567890\",",
+							"  \"name\": \"John Doe\",",
+							"  \"iat\": Math.floor(Date.now() / 1000), // issued now",
+							"  \"role\": pm.environment.get(\"allowed_role\")  // valid role to access status endpoint",
+							"}",
+							"",
+							"// encode header and payload",
+							"var encodedHeader = base64url(CryptoJS.enc.Utf8.parse(JSON.stringify(header)))",
+							"var encodedPayload = base64url(CryptoJS.enc.Utf8.parse(JSON.stringify(payload)))",
+							"",
+							"// create token",
+							"var token = encodedHeader + '.' + encodedPayload ",
+							"",
+							"// generate verify signature",
+							"var signature = base64url(CryptoJS.HmacSHA256(token, 'secret'))",
+							"",
+							"pm.variables.set('token', token + \".\" + signature)"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Host",
+						"value": "{{route_host}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://{{kong_host}}:{{kong_port}}/status/200",
+					"protocol": "http",
+					"host": [
+						"{{kong_host}}"
+					],
+					"port": "{{kong_port}}",
+					"path": [
+						"status",
+						"200"
+					]
+				},
+				"description": "Test the plugin with a Token that has a role allowed to access the service"
+			},
+			"response": []
 		}
 	],
 	"event": [
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "82ac6756-c2d9-44e2-9b69-8124ecb14a98",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -345,13 +498,11 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "3a3fbb08-62e2-4843-924c-20c7cbe6c995",
 				"type": "text/javascript",
 				"exec": [
 					""
 				]
 			}
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }

--- a/kong_api_authz/integration/testdata/postman/wait-for-services.sh
+++ b/kong_api_authz/integration/testdata/postman/wait-for-services.sh
@@ -5,7 +5,8 @@ set -e
 kong_host="$1"
 opa_host="$2"
 httpbin_host="$3"
-shift 3
+opaproxy_host="$4"
+shift 4
 cmd="$@"
 
 until $(curl --output /dev/null --silent --head --fail http://$kong_host/status); do
@@ -20,6 +21,11 @@ done
 
 until $(curl --output /dev/null --silent --head --fail http://$httpbin_host/status/200); do
   >&2 echo "Httpbin is unavailable - sleeping"
+  sleep 1
+done
+
+until $(curl --output /dev/null --silent --fail http://$opaproxy_host/proxies); do
+  >&2 echo "Toxiproxy is unavailable - sleeping"
   sleep 1
 done
 

--- a/kong_api_authz/integration/toxiproxy.json
+++ b/kong_api_authz/integration/toxiproxy.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "opaProxy",
+    "listen": "[::]:8181",
+    "upstream": "opa:8181",
+    "enabled": true
+  }
+]

--- a/kong_api_authz/spec/__mocks__/resty/http.lua
+++ b/kong_api_authz/spec/__mocks__/resty/http.lua
@@ -3,11 +3,25 @@ local _M = {}
 local mt = { __index = _M }
 
 function _M.new(_)
-    return setmetatable({ sock = "", keepalive = true }, mt)
+    return setmetatable({ sock = "", keepalive = true, timeouts = {} }, mt)
+end
+
+function _M.set_timeouts(self, connect_timeout, send_timeout, read_timeout)
+    -- store timeouts for later use in simulation of timeout scenarios
+    self.timeouts = {
+        connect_timeout = connect_timeout,
+        send_timeout = send_timeout,
+        read_timeout = read_timeout,
+    }
 end
 
 function _M.request_uri(self, uri, params)
     local res = {}
+
+    -- mock a timeout
+    if (self.timeouts.read_timeout == 999) then
+        return nil, "error"
+    end
 
     -- mock 400/500 OPA responses
     if (params.body:find("/error")) then

--- a/kong_api_authz/spec/kong/plugins/opa/access_spec.lua
+++ b/kong_api_authz/spec/kong/plugins/opa/access_spec.lua
@@ -7,6 +7,9 @@ local conf = {
     connection = {
       timeout = 5,
       pool = 1,
+      connect_timeout = 10,
+      send_timeout = 20,
+      read_timeout = 30,
     }
   },
   policy = {

--- a/kong_api_authz/src/kong/plugins/opa/access.lua
+++ b/kong_api_authz/src/kong/plugins/opa/access.lua
@@ -19,7 +19,11 @@ local function getDocument(input, conf)
         decision = conf.policy.decision
     })
 
-    local res, err = http.new():request_uri(opa_uri, {
+    local resty_http = http.new()
+    resty_http:set_timeouts(conf.server.connection.connect_timeout,
+        conf.server.connection.send_timeout,
+        conf.server.connection.read_timeout)
+    local res, err = resty_http:request_uri(opa_uri, {
         method = "POST",
         body = json_body,
         headers = {
@@ -30,6 +34,8 @@ local function getDocument(input, conf)
     })
 
     if err then
+        kong.log.err("Error calling OPA for URI " .. opa_uri ..
+            " ; error: ", err)
         error(err) -- failed to request the endpoint
     end
 

--- a/kong_api_authz/src/kong/plugins/opa/schema.lua
+++ b/kong_api_authz/src/kong/plugins/opa/schema.lua
@@ -53,6 +53,24 @@ return {
                           default = 10,
                         },
                       },
+                      {
+                        read_timeout = {
+                          type = "number",
+                          default = 1000,
+                        },
+                      },
+                      {
+                        send_timeout = {
+                          type = "number",
+                          default = 1000,
+                        },
+                      },
+                      {
+                        connect_timeout = {
+                          type = "number",
+                          default = 1000,
+                        },
+                      }
                     },
                   },
                 },


### PR DESCRIPTION
With this enhancement, Kong administrators have the _option_ to set timeouts on OPA policy evaluation calls.  This will enable API Gateway operators to guard against unruly OPA policies creeping into API transactions and blowing up request times.  