### PR TITLE
feat: Add bearer token support and trust self-signed CA for HTTPS in OPA

### DIFF
--- a/opa-iptables/go.mod
+++ b/opa-iptables/go.mod
@@ -3,7 +3,7 @@ module github.com/open-policy-agent/contrib/opa-iptables
 go 1.12
 
 require (
-	github.com/coreos/go-iptables v0.4.1
+	github.com/coreos/go-iptables v0.7.0
 	github.com/gorilla/mux v1.7.3
 	github.com/mattn/go-shellwords v1.0.5
 	github.com/sirupsen/logrus v1.4.2

--- a/opa-iptables/go.sum
+++ b/opa-iptables/go.sum
@@ -1,5 +1,5 @@
-github.com/coreos/go-iptables v0.4.1 h1:TyEMaK2xD/EcB0385QcvX/OvI2XI7s4SJEI2EhZFfEU=
-github.com/coreos/go-iptables v0.4.1/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
+github.com/coreos/go-iptables v0.7.0 h1:XWM3V+MPRr5/q51NuWSgU0fqMad64Zyxs8ZUoMsamr8=
+github.com/coreos/go-iptables v0.7.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=

--- a/opa-iptables/main.go
+++ b/opa-iptables/main.go
@@ -16,6 +16,8 @@ import (
 
 func main() {
 	opaEndpoint := flag.String("opa-endpoint", "http://127.0.0.1:8181", "endpoint of opa in form of http://ip:port i.e. http://192.33.0.1:8181")
+	opaAuthorization := flag.String("opa-authorization", "", "Bearer token for OPA authorization")
+	opaTrustedCAFile := flag.String("opa-trusted-cafile", "", "File path to the OPA trusted CA certificate")
 	controllerAddr := flag.String("controller-host", "0.0.0.0", "controller host")
 	// setting default port value to some high port to prevent accidentally block this port in IPTable rules
 	controllerPort := flag.String("controller-port", "33455", "controller port on which it listen on")
@@ -57,12 +59,14 @@ func main() {
 	}
 
 	controllerConfig := controller.Config{
-		OpaEndpoint:     *opaEndpoint,
-		ControllerAddr:  *controllerAddr,
-		ControllerPort:  *controllerPort,
-		WatcherInterval: *watcherInterval,
-		WatcherFlag:     *watcherFlag,
-		WorkerCount:     *workerCount,
+		OpaEndpoint:      *opaEndpoint,
+		ControllerAddr:   *controllerAddr,
+		ControllerPort:   *controllerPort,
+		WatcherInterval:  *watcherInterval,
+		WatcherFlag:      *watcherFlag,
+		WorkerCount:      *workerCount,
+		OpaAuthorization: *opaAuthorization,
+		OpaTrustedCAFile: *opaTrustedCAFile,
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/opa-iptables/pkg/controller/controller.go
+++ b/opa-iptables/pkg/controller/controller.go
@@ -17,7 +17,7 @@ func New(config Config) *Controller {
 	return &Controller{
 		logger:     logging.GetLogger(),
 		listenAddr: config.ControllerAddr + ":" + config.ControllerPort,
-		opaClient:  opa.New(config.OpaEndpoint, ""),
+		opaClient:  opa.New(config.OpaEndpoint, config.OpaAuthorization, config.OpaTrustedCAFile),
 		w: &watcher{
 			watcherInterval: config.WatcherInterval,
 			watcherState:    make(map[string]*state),
@@ -25,7 +25,7 @@ func New(config Config) *Controller {
 			logger:          logging.GetLogger(),
 		},
 		watcherWorkerCount: config.WorkerCount,
-		watcher:        config.WatcherFlag,
+		watcher:            config.WatcherFlag,
 	}
 }
 

--- a/opa-iptables/pkg/controller/types.go
+++ b/opa-iptables/pkg/controller/types.go
@@ -10,12 +10,14 @@ import (
 )
 
 type Config struct {
-	OpaEndpoint     string
-	ControllerAddr  string
-	ControllerPort  string
-	WatcherInterval time.Duration
-	WatcherFlag     bool
-	WorkerCount     int
+	OpaEndpoint      string
+	OpaAuthorization string
+	OpaTrustedCAFile string
+	ControllerAddr   string
+	ControllerPort   string
+	WatcherInterval  time.Duration
+	WatcherFlag      bool
+	WorkerCount      int
 }
 
 // Controller is a struct which is used for storing server related data.


### PR DESCRIPTION
- Added functionality to pass a bearer token during OPA connections.
- Registered the self-signed CA used to sign the OPA server certificate as a trusted CA, enabling HTTPS connections.