### PR TITLE
fix(cobertura): handle files without coverage gracefully

### DIFF
--- a/cobertura/opa_coverage_to_cobertura.py
+++ b/cobertura/opa_coverage_to_cobertura.py
@@ -64,6 +64,7 @@ def generate_package(coverage: OPACoverage) -> ET.Element:
     package.append(classes)
     for path, data in coverage.files.items():
         if isinstance(data, dict):
+            data["coverage"] = data.get("coverage", 0)
             data = FileCoverage(**data)
         class_data = ET.Element("class", attrib={
             "complexity": "0",


### PR DESCRIPTION
When a rego file is not covered, the script fails with an exception due to the OPA coverage format.
I added a small logic to handle this case gracefully 