### PR TITLE
Add missing READMEs for authzen, data_filter_azure, and wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This repository holds integrations, examples, and proof-of-concepts that work wi
 - [Grafana Dashboard](./grafana-dashboard)
 - [OpenAPI Specification for OPA](./open_api)
 - [SonarCloud Test Coverage Conversion](./sonarcloud)
+- [AuthZEN Interop](./authzen)
+- [WebAssembly](./wasm)
 
 For a comprehensive list of integrations, see the OPA [ecosystem](https://www.openpolicyagent.org/docs/latest/ecosystem/) page.
 

--- a/authzen/README.md
+++ b/authzen/README.md
@@ -1,0 +1,59 @@
+# AuthZEN Interop with OPA
+
+This directory contains the components for running OPA as an [AuthZEN](https://openid.github.io/authzen/)-compliant authorization service.
+
+The proxy translates between the AuthZEN evaluation API and OPA's data API so that any AuthZEN-compatible client can use OPA as a backend without modification.
+
+## Contents
+
+- [authzen-proxy](./authzen-proxy) - Node.js proxy server that exposes the AuthZEN evaluation endpoint and forwards requests to OPA
+- [authzen-interop](./authzen-interop) - Rego policies and test data for the AuthZEN interop scenario tests
+
+## Running
+
+Start OPA with the interop policies:
+
+```bash
+cd authzen-interop
+opa run -s -b policy --addr http://localhost:8181
+```
+
+In a separate terminal, start the proxy:
+
+```bash
+cd authzen-proxy
+npm install
+OPA_URL=http://localhost:8181 OPA_POLICY_PATH=authzen/allow npm start
+```
+
+The proxy listens on port `3000` by default. Send an AuthZEN evaluation request:
+
+```bash
+curl -X POST http://localhost:3000/access/v1/evaluation \
+  -H "Content-Type: application/json" \
+  -d '{
+    "subject": { "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs" },
+    "action": { "name": "can_read_todos" },
+    "resource": { "type": "todo" }
+  }'
+```
+
+## Configuration
+
+The proxy accepts the following environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `3000` | Port for the proxy server |
+| `OPA_URL` | `http://localhost:8181` | OPA server URL |
+| `OPA_POLICY_PATH` | `authzen/allow` | OPA policy path to evaluate |
+
+## Policy
+
+The included Rego policy (`authzen-interop/policy/authzen/authzen.rego`) implements role-based access control with the following roles:
+
+- **admin** - can create and delete resources
+- **editor** - can create, update (own), and delete (own) resources
+- **evil_genius** - can update any resource
+
+Reading users and todos is allowed for all authenticated users regardless of role.

--- a/data_filter_azure/README.md
+++ b/data_filter_azure/README.md
@@ -1,0 +1,10 @@
+# OPA Data Filtering on Azure
+
+This directory contains sample servers that use OPA for data filtering and authorization against Azure storage services. The servers are implemented in Python using Flask.
+
+Two variants are provided, each targeting a different Azure storage backend:
+
+- **[Cosmos DB (SQL API)](./README.documentdb.md)** - Uses OPA's Compile API to generate SQL conditions that are applied directly on Cosmos DB queries
+- **[Table Storage](./README.tablestorage.md)** - Uses OPA's Get Document API with input to query authorization data from Azure Table Storage at evaluation time
+
+See the linked READMEs above for setup instructions and usage details for each variant.

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,7 @@
+# OPA WebAssembly Examples
+
+This directory contains examples of using OPA policies compiled to WebAssembly (Wasm).
+
+## Examples
+
+- [Cloudflare Worker](./cloudflare-worker) - A Cloudflare Worker that enforces Rego policies compiled to Wasm at the edge. See its README for build, deployment, and usage instructions.


### PR DESCRIPTION
Three projects had no top-level README.

- `authzen/` - Overview, running instructions, configuration, and policy description
- `data_filter_azure/` - Overview with links to the existing `README.documentdb.md` and `README.tablestorage.md`
- `wasm/` - Overview with link to the cloudflare-worker subdirectory

Also added authzen and wasm to the project list in the root README.
