### PR TITLE
workflows: update setup-regal action to open-policy-agent org

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
       run: PATH=$PATH:$PWD:/home/runner/.local/bin make build
 
     - name: Setup Regal
-      uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # v1.0.0
+      uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f # v2.0.0
       with:
         version: v0.24.0
 


### PR DESCRIPTION
## Summary

- `StyraInc/setup-regal` has been moved to `open-policy-agent/setup-regal`
- The previous SHA (`33a142b1`) no longer resolves, causing CI to fail at the
  "Prepare all required actions" step before any build steps run
- Updates to `v2.0.0` (`761188c3`) from the new location