### PR TITLE
ci: fix broken builds in envoy_iptables and data_filter_azure

### DIFF
--- a/data_filter_azure/requirements.txt
+++ b/data_filter_azure/requirements.txt
@@ -1,7 +1,7 @@
 requests
 flask
 Flask-Bootstrap
-git+git://github.com/open-policy-agent/rego-python@master
+git+https://github.com/open-policy-agent/rego-python@master
 pytest
 azure-storage == 0.34.3
 azure-cosmos

--- a/envoy_iptables/Dockerfile
+++ b/envoy_iptables/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:jammy
 
 ADD ./proxy_init.sh /proxy_init.sh
 RUN chmod 755 /proxy_init.sh


### PR DESCRIPTION
## Summary

- **envoy_iptables**: Replace `ubuntu:xenial` (16.04 EOL) with `ubuntu:jammy`
  (22.04 LTS). The xenial arm64 repository on `ports.ubuntu.com` no longer
  provides valid GPG signatures, causing `apt-get install iptables` to fail
  on `linux/arm64` builds.

- **data_filter_azure**: Switch `rego-python` dependency from `git://` to
  `https://`. GitHub blocked the unauthenticated `git://` protocol in 2022,
  causing `pip install` to time out.